### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,7 +822,7 @@ mod tests {
     fn iter_test_rev() {
         let r = RectRange::from_ranges(4..7, 3..5).unwrap();
         let correct = [(4, 3), (5, 3), (6, 3), (4, 4), (5, 4), (6, 4)];
-        for (&c, t) in correct.into_iter().rev().zip(r.into_iter().rev()) {
+        for (&c, t) in correct.iter().rev().zip(r.into_iter().rev()) {
             assert_eq!(c, t);
         }
     }


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.